### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,7 @@ endmacro()
 # Compiler Settings
 #############################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
 add_subdirectory(lbl)


### PR DESCRIPTION
When compiling the OxLM with the latest gcc, some errors may occur for the c++ 11 standard. Now the standard option of using c++ 11 is -std=c++11. By this way, these error are lost.
